### PR TITLE
Enable CORS

### DIFF
--- a/ping/src/main/java/com/demo/ping/PingApplication.java
+++ b/ping/src/main/java/com/demo/ping/PingApplication.java
@@ -2,6 +2,7 @@ package com.demo.ping;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +17,7 @@ public class PingApplication {
 		SpringApplication.run(PingApplication.class, args);
 	}
 
+	@CrossOrigin
 	@GetMapping("/ping")
 	public String ping(@RequestParam(defaultValue = "To ping, or not to ping; that is the question.") String ping) {
 		JSONObject pong = new JSONObject();


### PR DESCRIPTION
This PR enables CORS for all origins. Fixes the `'Access-Control-Allow-Origin'` missing error when fetch() calls are made to /ping server apis.