### PR TITLE
feat: update, fix, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Java/Spring with MySQL template for Crafting Sandbox
 
-This is a Java/[Spring](https://spring.io/) with MySQL template, configured for quick development setup in [Crafting Sandbox](https://crafting.readme.io/docs).
+This is a Java/[Spring](https://spring.io/) with MySQL template, configured for quick development setup in [Crafting Sandbox](https://docs.sandboxes.cloud/docs).
 
 ## Specifications
 
@@ -41,40 +41,41 @@ To run the app:
 cd ping && ./gradlew bootRun
 ```
 
-## App configuration
+## App Definition
 
-The following [App configuration](https://crafting.readme.io/docs/app-spec) was used to create this template:
+The following [App Definition](https://docs.sandboxes.cloud/docs/app-definition) was used to create this template:
 
 ```yaml
 endpoints:
-- http:
-  routes:
-  - backend:
-      port: http
-      target: java-spring
-    path_prefix: /
-name: app
-services:
-- description: A Java/Spring template
-name: java-spring
-workspace:
-  checkouts:
-  - path: src/template-java-spring
-    repo:
-      git: https://github.com/crafting-dev/template-java-spring.git
-  packages:
-  - name: openjdk
-    version: ~14
+- name: api
+  http:
+    routes:
+    - pathPrefix: "/"
+      backend:
+        target: java-spring
+        port: api
+    authProxy:
+      disabled: true
+workspaces:
+- name: java-spring
+  description: Template backend using Java/Spring
   ports:
-  - name: http
+  - name: api
     port: 3000
     protocol: HTTP/TCP
-- managed_service:
+  checkouts:
+  - path: backend
+    repo:
+      git: https://github.com/crafting-dev/template-java-spring
+  packages:
+  - name: openjdk
+    version: 14.0.2
+dependencies:
+- name: mysql
+  serviceType: mysql
+  version: '8'
   properties:
     database: superhero
     password: batman
     username: brucewayne
-  service_type: mysql
-  version: "8"
-name: mysql
 ```


### PR DESCRIPTION
These set of PRs will fix all issues currently present in templates, such as routing issues for backend service, missing `npm installs` post checkout, outdated App Definitions, CORS issues, inconsistent query responses etc. With these updates, any frontend/backend configuration should work out of the box.

All templates will have the following behaviours:

- All 4 frontend templates will have the same interactive UI.
- All 7 backend templates will handle `/ping` requests, and will respond with either a query string `?ping=` (if present), or the phrase `'To ping, or not to ping; that is the question.'`, along with the current timestamp.

[Templates](https://sandboxes.cloud/sandboxes/templates) sandbox is currently available for testing in `crafting-contrib` using these updated branches, from an updated [template](https://sandboxes.cloud/apps/c6c54ee2top8eep5d6q0) App (which contains all template workspaces).